### PR TITLE
Handle correct transformation of `@tracked` property

### DIFF
--- a/transforms/tracked-properties/README.md
+++ b/transforms/tracked-properties/README.md
@@ -9,13 +9,15 @@ npx ember-tracked-properties-codemod path/of/files/ or/some**/*glob.js
 ## Input / Output
 
 <!--FIXTURES_TOC_START-->
-* [basic-with-prefix-false](#basic-with-prefix-false)
-* [basic](#basic)
-* [chained-complex-computed](#chained-complex-computed)
-* [chained-computed](#chained-computed)
-* [complex](#complex)
-* [with-tracked](#with-tracked)
-<!--FIXTURES_TOC_END-->
+
+- [basic-with-prefix-false](#basic-with-prefix-false)
+- [basic](#basic)
+- [chained-complex-computed](#chained-complex-computed)
+- [chained-computed](#chained-computed)
+- [complex](#complex)
+- [non-computed-decorators](#non-computed-decorators)
+- [with-tracked](#with-tracked)
+  <!--FIXTURES_TOC_END-->
 
 ## <!--FIXTURES_CONTENT_START-->
 
@@ -263,6 +265,63 @@ export default class AddTeamComponent extends Component {
   @action
   addTeam() {
     this.team.addTeamName(this.teamName);
+  }
+}
+```
+
+---
+
+<a id="non-computed-decorators">**non-computed-decorators**</a>
+
+**Input** (<small>[non-computed-decorators.input.js](__testfixtures__/non-computed-decorators.input.js)</small>):
+
+```js
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import { alias } from '@ember/object/computed';
+
+export default class Foo extends Component {
+  bar;
+  baz = 'barBaz';
+
+  @alias('model.isFoo')
+  isFoo;
+
+  @computed('baz', 'isFoo')
+  get bazInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'baz')}` : 'Baz';
+  }
+
+  @computed('bar', 'isFoo').readOnly()
+  get barInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'bab')}` : 'Bar';
+  }
+}
+```
+
+**Output** (<small>[non-computed-decorators.output.js](__testfixtures__/non-computed-decorators.output.js)</small>):
+
+```js
+import { tracked } from '@glimmer/tracking';
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import { alias } from '@ember/object/computed';
+
+export default class Foo extends Component {
+  bar;
+  @tracked baz = 'barBaz';
+
+  @alias('model.isFoo')
+  isFoo;
+
+  @computed('isFoo')
+  get bazInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'baz')}` : 'Baz';
+  }
+
+  @computed('bar', 'isFoo').readOnly()
+  get barInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'bab')}` : 'Bar';
   }
 }
 ```

--- a/transforms/tracked-properties/README.md
+++ b/transforms/tracked-properties/README.md
@@ -282,6 +282,7 @@ import { alias } from '@ember/object/computed';
 
 export default class Foo extends Component {
   bar;
+  // baz class property
   baz = 'barBaz';
 
   @alias('model.isFoo')
@@ -309,6 +310,7 @@ import { alias } from '@ember/object/computed';
 
 export default class Foo extends Component {
   bar;
+  // baz class property
   @tracked baz = 'barBaz';
 
   @alias('model.isFoo')

--- a/transforms/tracked-properties/__testfixtures__/non-computed-decorators.input.js
+++ b/transforms/tracked-properties/__testfixtures__/non-computed-decorators.input.js
@@ -4,6 +4,7 @@ import { alias } from '@ember/object/computed';
 
 export default class Foo extends Component {
   bar;
+  // baz class property
   baz = 'barBaz';
 
   @alias('model.isFoo')

--- a/transforms/tracked-properties/__testfixtures__/non-computed-decorators.input.js
+++ b/transforms/tracked-properties/__testfixtures__/non-computed-decorators.input.js
@@ -1,0 +1,21 @@
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import { alias } from '@ember/object/computed';
+
+export default class Foo extends Component {
+  bar;
+  baz = 'barBaz';
+
+  @alias('model.isFoo')
+  isFoo;
+
+  @computed('baz', 'isFoo')
+  get bazInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'baz')}` : 'Baz';
+  }
+
+  @computed('bar', 'isFoo').readOnly()
+  get barInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'bab')}` : 'Bar';
+  }
+}

--- a/transforms/tracked-properties/__testfixtures__/non-computed-decorators.output.js
+++ b/transforms/tracked-properties/__testfixtures__/non-computed-decorators.output.js
@@ -1,0 +1,22 @@
+import { tracked } from '@glimmer/tracking';
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import { alias } from '@ember/object/computed';
+
+export default class Foo extends Component {
+  bar;
+  @tracked baz = 'barBaz';
+
+  @alias('model.isFoo')
+  isFoo;
+
+  @computed('isFoo')
+  get bazInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'baz')}` : 'Baz';
+  }
+
+  @computed('bar', 'isFoo').readOnly()
+  get barInfo() {
+    return get(this, 'isFoo') ? `Name: ${get(this, 'bab')}` : 'Bar';
+  }
+}

--- a/transforms/tracked-properties/__testfixtures__/non-computed-decorators.output.js
+++ b/transforms/tracked-properties/__testfixtures__/non-computed-decorators.output.js
@@ -5,6 +5,7 @@ import { alias } from '@ember/object/computed';
 
 export default class Foo extends Component {
   bar;
+  // baz class property
   @tracked baz = 'barBaz';
 
   @alias('model.isFoo')

--- a/transforms/tracked-properties/utils/helper.js
+++ b/transforms/tracked-properties/utils/helper.js
@@ -59,13 +59,15 @@ function _doesContainNonLocalArgs(argItem, computedMap, classProperties) {
 
   while (stack.size() > 0) {
     currItem = stack.pop();
-    // If currItem is not a class property, return true.
-    if (!classProperties.includes(currItem)) {
+    const dependentKeys = computedMap[currItem];
+
+    // If currItem is not a class property and
+    // if it is not a computed property with dependent keys, return true.
+    if (!classProperties.includes(currItem) && !dependentKeys) {
       return true;
     }
     // If currItem itself is a computed property, then it would have dependent keys.
     // Get the dependent keys and push them in the stack.
-    const dependentKeys = computedMap[currItem];
     if (dependentKeys) {
       stack.push(...dependentKeys);
     }
@@ -78,15 +80,13 @@ function _doesContainNonLocalArgs(argItem, computedMap, classProperties) {
  * the key and values provided.
  * @param {*} macroName
  * @param {*} name
- * @param {*} value
  * @param {*} j
  */
-function buildTrackedDecorator(name, value, j) {
+function buildTrackedDecorator(name, j) {
   var node = j('class Fake { @tracked' + ' ' + name + '; \n}')
     .find(j.ClassProperty)
     .get().node;
-  node.value = value;
-  return node;
+  return node.decorators;
 }
 
 /**


### PR DESCRIPTION
Currently, the codemod completely replaces the `classProperty` node to a new node with `@tracked` due to which all other essential information regarding that `classProperty` is lost.

Eg:
```
import Component from "@ember/component";
import { computed, get } from "@ember/object";
import { alias } from "@ember/object/computed";

export default class Foo extends Component {
  bar;
  // baz class property
  baz = 'barBaz';

  @alias('model.isFoo')
  isFoo;

  @computed('baz', 'isFoo')
  get bazInfo() {
    return `Name: ${get(this, 'baz')}`;
  }
}
```

gets converted to 

```
import { tracked } from "@glimmer/tracking";
import Component from "@ember/component";
import { computed, get } from "@ember/object";
import { alias } from "@ember/object/computed";

export default class Foo extends Component {
  bar;
  @tracked baz = "barBaz";

  @tracked isFoo;

  get bazInfo() {
    return `Name: ${get(this, "baz")}`;
  }
}

```

In the example above, the comment `// baz class property` got lost while it got converted. Also, the `@alias` got replaced by `@tracked` which is incorrect.
This PR solves both issues.