### PR TITLE
Fix the removal of computed decorators

### DIFF
--- a/transforms/tracked-properties/README.md
+++ b/transforms/tracked-properties/README.md
@@ -141,7 +141,7 @@ export default class Foo extends Component {
     return `Name: ${get(this, 'firstName')} ${get(this, 'lastName')}`;
   }
 
-  @computed('areaCode')
+  @computed('areaCode', 'phone')
   get phoneNumber() {
     return `(${get(this, 'areaCode')}) ${get(this, 'phone')}`;
   }
@@ -190,15 +190,17 @@ export default class Foo extends Component {
   @tracked foo = 'bar';
   baz;
 
+  @computed('foo')
   get fooBar() {
     return `Foo: ${get(this, 'foo')}`;
   }
 
+  @computed('fooBar')
   get fooBarDetail() {
     return `Foo bar detail: ${get(this, 'fooBar')}`;
   }
 
-  @computed('bang')
+  @computed('fooBarDetail', 'bang')
   get fooBarDetailWithBaz() {
     return `(${get(this, 'fooBarDetail')}) ${get(this, 'baz')}`;
   }
@@ -252,7 +254,7 @@ export default class AddTeamComponent extends Component {
   @tracked teamName;
   @tracked noOfHackers;
 
-  @computed('fooBar')
+  @computed('fooBar', 'noOfHackers')
   get isMaxExceeded() {
     return this.noOfHackers > 10;
   }
@@ -316,12 +318,12 @@ export default class Foo extends Component {
   @alias('model.isFoo')
   isFoo;
 
-  @computed('isFoo')
+  @computed('baz', 'isFoo')
   get bazInfo() {
     return get(this, 'isFoo') ? `Name: ${get(this, 'baz')}` : 'Baz';
   }
 
-  @(computed('isFoo').readOnly())
+  @computed('bar', 'isFoo').readOnly()
   get barInfo() {
     return get(this, 'isFoo') ? `Name: ${get(this, 'bar')}` : 'Bar';
   }
@@ -385,7 +387,7 @@ export default class Foo extends Component {
     return `Bar: ${get(this, 'bar')}, Baz: ${get(this, 'baz')}`;
   }
 
-  @(computed('isFoo').readOnly())
+  @(computed('bar', 'isFoo').readOnly())
   get barInfo() {
     return get(this, 'isFoo') ? `Name: ${get(this, 'bar')}` : 'Bar';
   }

--- a/transforms/tracked-properties/__testfixtures__/chained-complex-computed.output.js
+++ b/transforms/tracked-properties/__testfixtures__/chained-complex-computed.output.js
@@ -8,7 +8,7 @@ export default class AddTeamComponent extends Component {
   @tracked teamName;
   @tracked noOfHackers;
 
-  @computed('fooBar')
+  @computed('fooBar', 'noOfHackers')
   get isMaxExceeded() {
     return this.noOfHackers > 10;
   }

--- a/transforms/tracked-properties/__testfixtures__/chained-computed.output.js
+++ b/transforms/tracked-properties/__testfixtures__/chained-computed.output.js
@@ -6,15 +6,17 @@ export default class Foo extends Component {
   @tracked foo = 'bar';
   baz;
 
+  @computed('foo')
   get fooBar() {
     return `Foo: ${get(this, 'foo')}`;
   }
 
+  @computed('fooBar')
   get fooBarDetail() {
     return `Foo bar detail: ${get(this, 'fooBar')}`;
   }
 
-  @computed('bang')
+  @computed('fooBarDetail', 'bang')
   get fooBarDetailWithBaz() {
     return `(${get(this, 'fooBarDetail')}) ${get(this, 'baz')}`;
   }

--- a/transforms/tracked-properties/__testfixtures__/complex.output.js
+++ b/transforms/tracked-properties/__testfixtures__/complex.output.js
@@ -12,7 +12,7 @@ export default class Foo extends Component {
     return `Name: ${get(this, 'firstName')} ${get(this, 'lastName')}`;
   }
 
-  @computed('areaCode')
+  @computed('areaCode', 'phone')
   get phoneNumber() {
     return `(${get(this, 'areaCode')}) ${get(this, 'phone')}`;
   }

--- a/transforms/tracked-properties/__testfixtures__/non-computed-decorators.output.js
+++ b/transforms/tracked-properties/__testfixtures__/non-computed-decorators.output.js
@@ -11,12 +11,12 @@ export default class Foo extends Component {
   @alias('model.isFoo')
   isFoo;
 
-  @computed('isFoo')
+  @computed('baz', 'isFoo')
   get bazInfo() {
     return get(this, 'isFoo') ? `Name: ${get(this, 'baz')}` : 'Baz';
   }
 
-  @computed('isFoo').readOnly()
+  @computed('bar', 'isFoo').readOnly()
   get barInfo() {
     return get(this, 'isFoo') ? `Name: ${get(this, 'bar')}` : 'Bar';
   }

--- a/transforms/tracked-properties/__testfixtures__/read-only-computed-decorators.output.js
+++ b/transforms/tracked-properties/__testfixtures__/read-only-computed-decorators.output.js
@@ -15,7 +15,7 @@ export default class Foo extends Component {
     return `Bar: ${get(this, 'bar')}, Baz: ${get(this, 'baz')}`;
   }
 
-  @(computed('isFoo').readOnly())
+  @(computed('bar', 'isFoo').readOnly())
   get barInfo() {
     return get(this, 'isFoo') ? `Name: ${get(this, 'bar')}` : 'Bar';
   }

--- a/transforms/tracked-properties/utils/helper.js
+++ b/transforms/tracked-properties/utils/helper.js
@@ -63,7 +63,7 @@ function _doesContainNonLocalArgs(argItem, computedMap, classProperties) {
 
     // If currItem is not a class property and
     // if it is not a computed property with dependent keys, return true.
-    if ((!classProperties.includes(currItem) && !dependentKeys) || Object.keys(computedMap).includes(currItem)) {
+    if (!classProperties.includes(currItem) && !dependentKeys) {
       return true;
     }
     // If currItem itself is a computed property, then it would have dependent keys.

--- a/transforms/tracked-properties/utils/helper.js
+++ b/transforms/tracked-properties/utils/helper.js
@@ -63,7 +63,7 @@ function _doesContainNonLocalArgs(argItem, computedMap, classProperties) {
 
     // If currItem is not a class property and
     // if it is not a computed property with dependent keys, return true.
-    if (!classProperties.includes(currItem) && !dependentKeys) {
+    if ((!classProperties.includes(currItem) && !dependentKeys) || Object.keys(computedMap).includes(currItem)) {
       return true;
     }
     // If currItem itself is a computed property, then it would have dependent keys.


### PR DESCRIPTION
Currently, the code removes the `@computed` decorator arguments which are `@tracked`, which would lead to incorrect behavior. 
Also, for a given computed property, removal of the whole `@computed` decorator should depend on 2 things:
1. If all the `args` of the decorator are `@tracked`.
2. The property itself should not be a dependent key of any other CP in the file