### PR TITLE
Feat: Include Glimmer component arguments as being tracked

### DIFF
--- a/transforms/tracked-properties/__testfixtures__/complex.input.js
+++ b/transforms/tracked-properties/__testfixtures__/complex.input.js
@@ -16,4 +16,9 @@ export default class Foo extends Component {
   get phoneNumber() {
     return `(${get(this, 'areaCode')}) ${get(this, 'phone')}`;
   }
+
+  @computed('args.foo')
+  get ignoreArgsInEmberComponent() {
+    return this.args.foo ?? 1;
+  }
 }

--- a/transforms/tracked-properties/__testfixtures__/complex.output.js
+++ b/transforms/tracked-properties/__testfixtures__/complex.output.js
@@ -16,4 +16,9 @@ export default class Foo extends Component {
   get phoneNumber() {
     return `(${get(this, 'areaCode')}) ${get(this, 'phone')}`;
   }
+
+  @computed('args.foo')
+  get ignoreArgsInEmberComponent() {
+    return this.args.foo ?? 1;
+  }
 }

--- a/transforms/tracked-properties/__testfixtures__/glimmer-args.input.js
+++ b/transforms/tracked-properties/__testfixtures__/glimmer-args.input.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { computed } from '@ember/object';
+
+export default class Foo extends Component {
+  @computed('args.foo')
+  get bazInfo() {
+    return this.args.foo ?? 1;
+  }
+
+  @computed('args.no.nested')
+  get noNested() {
+    return this.args.no.nested ?? 2;
+  }
+
+  @computed('args.{x,y,z}')
+  get braceExpansion() {
+    return this.args.x + this.args.y + this.args.z;
+  }
+}

--- a/transforms/tracked-properties/__testfixtures__/glimmer-args.output.js
+++ b/transforms/tracked-properties/__testfixtures__/glimmer-args.output.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { computed } from '@ember/object';
+
+export default class Foo extends Component {
+  get bazInfo() {
+    return this.args.foo ?? 1;
+  }
+
+  @computed('args.no.nested')
+  get noNested() {
+    return this.args.no.nested ?? 2;
+  }
+
+  get braceExpansion() {
+    return this.args.x + this.args.y + this.args.z;
+  }
+}

--- a/transforms/tracked-properties/index.js
+++ b/transforms/tracked-properties/index.js
@@ -4,6 +4,7 @@ const {
   getDependentKeys,
   buildTrackedDecorator,
   reformatTrackedDecorators,
+  filterGlimmerArgs,
 } = require('./utils/helper');
 
 const { getOptions } = require('codemod-cli');
@@ -148,11 +149,12 @@ module.exports = function transformer(file, api) {
                 ? decoratorItem.expression.callee.object.arguments
                 : decoratorItem.expression.arguments;
 
-              const dependentKeys = getDependentKeys(
+              let dependentKeys = getDependentKeys(
                 computedPropArguments,
                 computedPropsMap,
                 classProps
               );
+              dependentKeys = filterGlimmerArgs(dependentKeys);
               // If all the arguments of the decorator are class properties, then remove the decorator completely
               // from the item.
               if (!dependentKeys.length) {

--- a/transforms/tracked-properties/utils/helper.js
+++ b/transforms/tracked-properties/utils/helper.js
@@ -45,6 +45,14 @@ function getDependentKeys(computedArgs, computedPropsMap, classProperties) {
 }
 
 /**
+ * Return the array of arguments that are not simple, non-nested, Glimmer component arguments.
+ * @param {*} computedArgs
+ */
+function filterGlimmerArgs(computedArgs) {
+  return computedArgs.filter(argItem => !(argItem.value.startsWith('args.') && argItem.value.split('.').length === 2))
+}
+
+/**
  * Checks the chained dependency among the arguments to see if there is any
  * value that is not a local class property.
  * Returns true if there is any property that is not a local class property.
@@ -120,4 +128,5 @@ module.exports = {
   getDependentKeys,
   buildTrackedDecorator,
   reformatTrackedDecorators,
+  filterGlimmerArgs,
 };


### PR DESCRIPTION
Glimmer component arguments are auto tracked by default. So when in a Glimmer component, we can safely ignore these if they're part of the computed property watchlist.

This is only true for the reference of the argument itself, and not nested properties. For this a check has been added as well.